### PR TITLE
fix OTP-26.2 src checksum

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -28,7 +28,7 @@
 	    "alpine": "3.19",
 	    "rebar3": "3.22.1",
 	    "version": "26.2",
-	    "download_sha256": "575df666c678bbbcf97fbf8dec532db62c25b3aec005a2ba1348982c8e9661bb"
+	    "download_sha256": "a85fa668a292868a7dc8c8ac18615995051392acbfbfa9cef1e8d84cf417ca87"
 	}
     },
     "rebar3": {


### PR DESCRIPTION
The OTP release process uploads the the src.tar.gz twice. Some timestamps differ between the two uploads, resulting in a changed checksum.

Replace the old csum with the newer one.