### PR TITLE
OTP-25.3.2.20, OTP-26.2.5.11, OTP-27.3.3 and OTP-28.0-rc4

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -9,14 +9,14 @@
 	"25.3":	{
 	    "alpine": "3.17",
 	    "rebar3": "3.20",
-	    "version": "25.3.2.18",
-	    "download_sha256": "6ea82a2d3907d94c7d044795708fecf0af580ec6488a0673d2085dd1ea40b499"
+	    "version": "25.3.2.20",
+	    "download_sha256": "9dda848291428c02d8373f32da5dabf7c1a1478d9cba268fa85475eb26371fe7"
 	},
 	"26.2":	{
 	    "alpine": "3.19",
 	    "rebar3": "3.22.1",
-	    "version": "26.2.5.9",
-	    "download_sha256": "fb626d82c6a4fb7a85db8f8f12c8689ad669791d58982f91b05d226785b56175"
+	    "version": "26.2.5.11",
+	    "download_sha256": "69cf6c2cc4e54e8d0bab8f9893f0b61dee10bff575c3535d47b6057a468751b1"
 	},
 	"27.2":	{
 	    "alpine": "3.21",
@@ -27,14 +27,14 @@
 	"27.3":	{
 	    "alpine": "3.21",
 	    "rebar3": "3.24.0",
-	    "version": "27.3",
-	    "download_sha256": "efe76126938f237c0d3a0e2e8753c5cb823235d4d53708833bbc0968d76c39b8"
+	    "version": "27.3.3",
+	    "download_sha256": "5c5c69c7816c97e33f7f8efaab44b4465dc62365f5a60a7fb2a132f6e116748e"
 	},
-	"28.0-rc1":	{
-	    "alpine": "3.21",
+	"28.0-rc4":	{
+	    "alpine": "edge",
 	    "rebar3": "3.24.0-23-gaf0a425",
-	    "version": "28.0-rc1",
-	    "download_sha256": "cab460bdbecb6afc8a0d016127120b14fa384a7db37a15f2750bef2e1a12d330"
+	    "version": "28.0-rc4",
+	    "download_sha256": "abd35efea2b886813ab250f62b61d5a8c17f89bba7fd55c1c7f5aec15576f1a8"
 	}
    },
     "rebar3": {


### PR DESCRIPTION
Temporary bump Alpine to edge for OTP-28.0-rc4. Alpine 3.22 will be released before the end of the month, 28.0 is not for production (yet), but testing it already on newer Alpine is worthwhile.