### PR TITLE
Add multi-architecture build support with native ARM64 runners

### DIFF
--- a/.github/actions/load-otp-env/action.yml
+++ b/.github/actions/load-otp-env/action.yml
@@ -1,0 +1,42 @@
+name: 'Load OTP Environment'
+description: 'Load OTP version information from versions.json'
+inputs:
+  otp-version:
+    description: 'OTP major version (e.g., 27.3)'
+    required: true
+outputs:
+  env:
+    description: 'JSON object with all environment variables'
+    value: ${{ steps.load-env.outputs.env }}
+  otp-major:
+    description: 'OTP major version'
+    value: ${{ steps.load-env.outputs.otp-major }}
+  otp-version:
+    description: 'Full OTP version'
+    value: ${{ steps.load-env.outputs.otp-version }}
+  otp-alpine:
+    description: 'Alpine version'
+    value: ${{ steps.load-env.outputs.otp-alpine }}
+  alpine-major-minor:
+    description: 'Alpine major.minor version'
+    value: ${{ steps.load-env.outputs.alpine-major-minor }}
+  build-tag:
+    description: 'Unique build tag'
+    value: ${{ steps.load-env.outputs.build-tag }}
+
+runs:
+  using: 'composite'
+  steps:
+    - id: load-env
+      shell: bash
+      run: |
+        load=$(jq -cr '{"OTP_MAJOR": "${{ inputs.otp-version }}"} * (.otp."${{ inputs.otp-version }}" | with_entries(.key |= "OTP_" + ascii_upcase)) * (.rebar3."\(.otp."${{ inputs.otp-version }}".rebar3)" | with_entries(.key |= "REBAR3_" + ascii_upcase))' versions.json)
+        tag=$(echo $load | jq -cr ".OTP_VERSION + \":\" + .REBAR3_VERSION + \":$GITHUB_RUN_ID\"" | sha256sum | cut -b -7)
+        alpine_major_minor=$(echo "$load" | jq -cr '.OTP_ALPINE | split(".") | .[0:2] | join(".")')
+        load=$(echo "$load" | jq -cr ". + {\"TAG\":\"$tag\", \"ALPINE_MAJOR_MINOR\":\"$alpine_major_minor\"}")
+        echo "env=$load" >> $GITHUB_OUTPUT
+        echo "otp-major=${{ inputs.otp-version }}" >> $GITHUB_OUTPUT
+        echo "otp-version=$(echo "$load" | jq -r '.OTP_VERSION')" >> $GITHUB_OUTPUT
+        echo "otp-alpine=$(echo "$load" | jq -r '.OTP_ALPINE')" >> $GITHUB_OUTPUT
+        echo "alpine-major-minor=$(echo "$load" | jq -r '.ALPINE_MAJOR_MINOR')" >> $GITHUB_OUTPUT
+        echo "build-tag=$(echo "$load" | jq -r '.TAG')" >> $GITHUB_OUTPUT

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -219,7 +219,7 @@ jobs:
       -
         name: Login to Registry
         run: |
-          podman login quay.io -u ${{ secrets.QUAY_USERNAME }} -p ${{ secrets.QUAY_TOKEN }}
+          echo "${{ secrets.QUAY_TOKEN }}" | podman login -u "${{ secrets.QUAY_USERNAME }}" --password-stdin quay.io
       -
         name: Create and Push Multi-arch Manifests
         env: ${{ fromJson(steps.load-env.outputs.env) }}

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   matrix:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -22,9 +22,108 @@ jobs:
           echo "Matrix: $matrix"
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
-  images:
+  build-amd64:
     needs: matrix
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
+      fail-fast: false
+    outputs:
+      project: ${{ steps.repo.outputs.project }}
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Choose Repository
+        id: repo
+        run: |
+          case ${{ github.ref }} in
+            refs/heads/master)
+                echo "project=alpine-erlang" >> $GITHUB_OUTPUT
+                ;;
+            *)
+                echo "project=alpine-erlang-dev" >> $GITHUB_OUTPUT
+                ;;
+          esac
+      -
+        name: Load Env
+        id: load-env
+        run: |
+          load=$(jq -cr '{"OTP_MAJOR": "${{ matrix.otp }}"} * (.otp."${{ matrix.otp }}" | with_entries(.key |= "OTP_" + ascii_upcase)) * (.rebar3."\(.otp."${{ matrix.otp }}".rebar3)" | with_entries(.key |= "REBAR3_" + ascii_upcase))' versions.json)
+          tag=$(echo $load | jq -cr ".OTP_VERSION + \":\" + .REBAR3_VERSION + \":$GITHUB_RUN_ID\"" | sha256sum | cut -b -7)
+          alpine_major_minor=$(echo "$load" | jq -cr '.OTP_ALPINE | split(".") | .[0:2] | join(".")')
+          load=$(echo "$load" | jq -cr ". + {\"TAG\":\"$tag\", \"ALPINE_MAJOR_MINOR\":\"$alpine_major_minor\"}")
+          echo "env=$load" >> $GITHUB_OUTPUT
+          # Export tags for manifest job
+          echo "otp_major=${{ matrix.otp }}" >> $GITHUB_OUTPUT
+          echo "otp_version=$(echo "$load" | jq -r '.OTP_VERSION')" >> $GITHUB_OUTPUT
+          echo "otp_alpine=$(echo "$load" | jq -r '.OTP_ALPINE')" >> $GITHUB_OUTPUT
+          echo "alpine_major_minor=$(echo "$load" | jq -r '.ALPINE_MAJOR_MINOR')" >> $GITHUB_OUTPUT
+          echo "build_tag=$(echo "$load" | jq -r '.TAG')" >> $GITHUB_OUTPUT
+      -
+        name: Docker Metadata
+        env: ${{ fromJson(steps.load-env.outputs.env) }}
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            quay.io/travelping/${{ steps.repo.outputs.project }}
+          tags: |
+            type=raw,value=${{ env.TAG }}-amd64
+            type=raw,value=${{ env.OTP_MAJOR }}-amd64
+            type=raw,value=${{ env.OTP_VERSION }}-amd64
+            type=raw,value=${{ env.OTP_VERSION }}-alpine-${{ env.ALPINE_MAJOR_MINOR }}-amd64
+            type=raw,value=${{ env.OTP_VERSION }}-alpine-${{ env.OTP_ALPINE }}-amd64
+            type=raw,value=${{ env.OTP_MAJOR }}-alpine-${{ env.ALPINE_MAJOR_MINOR }}-amd64
+            type=raw,value=${{ env.OTP_MAJOR }}-alpine-${{ env.OTP_ALPINE }}-amd64
+      -
+        name: Install Packages
+        run: |
+          sudo apt update
+          sudo apt full-upgrade -y
+          sudo apt install buildah podman
+      -
+        name: Build Image
+        env: ${{ fromJson(steps.load-env.outputs.env) }}
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          build-args: |
+            ALPINE_VERSION=alpine:${{ env.OTP_ALPINE }}
+            OTP_VERSION=${{ env.OTP_VERSION }}
+            OTP_DOWNLOAD_SHA256=${{ env.OTP_DOWNLOAD_SHA256 }}
+            REBAR3_VERSION=${{ env.REBAR3_VERSION }}
+            REBAR3_DOWNLOAD_SHA256=${{ env.REBAR3_DOWNLOAD_SHA256 }}
+          image: ${{ steps.meta.outputs.images }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+          extra-args: |
+            --security-opt seccomp=unconfined
+          oci: true
+          containerfiles: |
+            ./Containerfile
+      -
+        name: Check images created
+        run: buildah images
+      -
+        name: Push To Registry
+        id: push-to-registry
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+      -
+        name: Print image url
+        run: |
+          echo "Image pushed to ${{ steps.push-to-registry.outputs.registry-paths }}"
+
+  build-arm64:
+    needs: matrix
+    runs-on: ubuntu-24.04-arm64
     strategy:
       matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
       fail-fast: false
@@ -62,19 +161,19 @@ jobs:
           images: |
             quay.io/travelping/${{ steps.repo.outputs.project }}
           tags: |
-            type=raw,value=${{ env.TAG }}
-            type=raw,value=${{ env.OTP_MAJOR }}
-            type=raw,value=${{ env.OTP_VERSION }}
-            type=raw,value=${{ env.OTP_VERSION }}-alpine-${{ env.ALPINE_MAJOR_MINOR }}
-            type=raw,value=${{ env.OTP_VERSION }}-alpine-${{ env.OTP_ALPINE }}
-            type=raw,value=${{ env.OTP_MAJOR }}-alpine-${{ env.ALPINE_MAJOR_MINOR }}
-            type=raw,value=${{ env.OTP_MAJOR }}-alpine-${{ env.OTP_ALPINE }}
+            type=raw,value=${{ env.TAG }}-arm64
+            type=raw,value=${{ env.OTP_MAJOR }}-arm64
+            type=raw,value=${{ env.OTP_VERSION }}-arm64
+            type=raw,value=${{ env.OTP_VERSION }}-alpine-${{ env.ALPINE_MAJOR_MINOR }}-arm64
+            type=raw,value=${{ env.OTP_VERSION }}-alpine-${{ env.OTP_ALPINE }}-arm64
+            type=raw,value=${{ env.OTP_MAJOR }}-alpine-${{ env.ALPINE_MAJOR_MINOR }}-arm64
+            type=raw,value=${{ env.OTP_MAJOR }}-alpine-${{ env.OTP_ALPINE }}-arm64
       -
         name: Install Packages
         run: |
           sudo apt update
           sudo apt full-upgrade -y
-          sudo apt install qemu-user-static buildah podman
+          sudo apt install buildah podman
       -
         name: Build Image
         env: ${{ fromJson(steps.load-env.outputs.env) }}
@@ -90,10 +189,7 @@ jobs:
           image: ${{ steps.meta.outputs.images }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64
-          # building Erlang/OTP 25.0 for arm64 on QEMU  user emulation is broken,
-          # see https://erlangforums.com/t/otp-25-0-rc3-release-candidate-3-is-released/1317/24
-          # platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           extra-args: |
             --security-opt seccomp=unconfined
           oci: true
@@ -103,8 +199,8 @@ jobs:
         name: Check images created
         run: buildah images
       -
-        name: Push To Harbor
-        id: push-to-harbor
+        name: Push To Registry
+        id: push-to-registry
         uses: redhat-actions/push-to-registry@v2
         with:
           image: ${{ steps.build-image.outputs.image }}
@@ -114,5 +210,104 @@ jobs:
       -
         name: Print image url
         run: |
-          echo -e "Image pushed to:\n" | tee -a $GITHUB_STEP_SUMMARY
-          echo "${{ steps.push-to-harbor.outputs.registry-paths }}" | yq -P | tee -a $GITHUB_STEP_SUMMARY
+          echo "Image pushed to ${{ steps.push-to-registry.outputs.registry-paths }}"
+
+  manifest:
+    needs: [matrix, build-amd64, build-arm64]
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
+      fail-fast: false
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Choose Repository
+        id: repo
+        run: |
+          case ${{ github.ref }} in
+            refs/heads/master)
+                echo "project=alpine-erlang" >> $GITHUB_OUTPUT
+                ;;
+            *)
+                echo "project=alpine-erlang-dev" >> $GITHUB_OUTPUT
+                ;;
+          esac
+      -
+        name: Load Env
+        id: load-env
+        run: |
+          load=$(jq -cr '{"OTP_MAJOR": "${{ matrix.otp }}"} * (.otp."${{ matrix.otp }}" | with_entries(.key |= "OTP_" + ascii_upcase)) * (.rebar3."\(.otp."${{ matrix.otp }}".rebar3)" | with_entries(.key |= "REBAR3_" + ascii_upcase))' versions.json)
+          tag=$(echo $load | jq -cr ".OTP_VERSION + \":\" + .REBAR3_VERSION + \":$GITHUB_RUN_ID\"" | sha256sum | cut -b -7)
+          alpine_major_minor=$(echo "$load" | jq -cr '.OTP_ALPINE | split(".") | .[0:2] | join(".")')
+          load=$(echo "$load" | jq -cr ". + {\"TAG\":\"$tag\", \"ALPINE_MAJOR_MINOR\":\"$alpine_major_minor\"}")
+          echo "env=$load" >> $GITHUB_OUTPUT
+      -
+        name: Install Packages
+        run: |
+          sudo apt update
+          sudo apt install podman
+      -
+        name: Login to Registry
+        run: |
+          podman login quay.io -u ${{ secrets.QUAY_USERNAME }} -p ${{ secrets.QUAY_TOKEN }}
+      -
+        name: Create and Push Multi-arch Manifests
+        env: ${{ fromJson(steps.load-env.outputs.env) }}
+        run: |
+          set -x
+          
+          IMAGE_BASE="quay.io/travelping/${{ steps.repo.outputs.project }}"
+          
+          # Array of all tag combinations
+          TAGS=(
+            "${{ env.TAG }}"
+            "${{ env.OTP_MAJOR }}"
+            "${{ env.OTP_VERSION }}"
+            "${{ env.OTP_VERSION }}-alpine-${{ env.ALPINE_MAJOR_MINOR }}"
+            "${{ env.OTP_VERSION }}-alpine-${{ env.OTP_ALPINE }}"
+            "${{ env.OTP_MAJOR }}-alpine-${{ env.ALPINE_MAJOR_MINOR }}"
+            "${{ env.OTP_MAJOR }}-alpine-${{ env.OTP_ALPINE }}"
+          )
+          
+          # Create and push manifest for each tag
+          for TAG in "${TAGS[@]}"; do
+            MANIFEST_NAME="${IMAGE_BASE}:${TAG}"
+            AMD64_IMAGE="${IMAGE_BASE}:${TAG}-amd64"
+            ARM64_IMAGE="${IMAGE_BASE}:${TAG}-arm64"
+            
+            echo "Creating manifest: $MANIFEST_NAME"
+            
+            # Create manifest
+            podman manifest create "$MANIFEST_NAME"
+            
+            # Add architecture-specific images
+            podman manifest add "$MANIFEST_NAME" "$AMD64_IMAGE"
+            podman manifest add "$MANIFEST_NAME" "$ARM64_IMAGE"
+            
+            # Inspect manifest
+            podman manifest inspect "$MANIFEST_NAME"
+            
+            # Push manifest
+            podman manifest push "$MANIFEST_NAME"
+            
+            echo "Pushed multi-arch manifest: $MANIFEST_NAME"
+          done
+      -
+        name: Print Summary
+        env: ${{ fromJson(steps.load-env.outputs.env) }}
+        run: |
+          echo -e "## Multi-arch images pushed\n" | tee -a $GITHUB_STEP_SUMMARY
+          echo "Base: quay.io/travelping/${{ steps.repo.outputs.project }}" | tee -a $GITHUB_STEP_SUMMARY
+          echo "" | tee -a $GITHUB_STEP_SUMMARY
+          echo "Tags:" | tee -a $GITHUB_STEP_SUMMARY
+          echo "- ${{ env.TAG }}" | tee -a $GITHUB_STEP_SUMMARY
+          echo "- ${{ env.OTP_MAJOR }}" | tee -a $GITHUB_STEP_SUMMARY
+          echo "- ${{ env.OTP_VERSION }}" | tee -a $GITHUB_STEP_SUMMARY
+          echo "- ${{ env.OTP_VERSION }}-alpine-${{ env.ALPINE_MAJOR_MINOR }}" | tee -a $GITHUB_STEP_SUMMARY
+          echo "- ${{ env.OTP_VERSION }}-alpine-${{ env.OTP_ALPINE }}" | tee -a $GITHUB_STEP_SUMMARY
+          echo "- ${{ env.OTP_MAJOR }}-alpine-${{ env.ALPINE_MAJOR_MINOR }}" | tee -a $GITHUB_STEP_SUMMARY
+          echo "- ${{ env.OTP_MAJOR }}-alpine-${{ env.OTP_ALPINE }}" | tee -a $GITHUB_STEP_SUMMARY
+          echo "" | tee -a $GITHUB_STEP_SUMMARY
+          echo "Architectures: linux/amd64, linux/arm64" | tee -a $GITHUB_STEP_SUMMARY

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -69,12 +69,6 @@ jobs:
             type=raw,value=${{ env.OTP_MAJOR }}-alpine-${{ env.ALPINE_MAJOR_MINOR }}-amd64
             type=raw,value=${{ env.OTP_MAJOR }}-alpine-${{ env.OTP_ALPINE }}-amd64
       -
-        name: Install Packages
-        run: |
-          sudo apt update
-          sudo apt full-upgrade -y
-          sudo apt install buildah podman
-      -
         name: Build Image
         env: ${{ fromJson(steps.load-env.outputs.env) }}
         id: build-image
@@ -157,12 +151,6 @@ jobs:
             type=raw,value=${{ env.OTP_MAJOR }}-alpine-${{ env.ALPINE_MAJOR_MINOR }}-arm64
             type=raw,value=${{ env.OTP_MAJOR }}-alpine-${{ env.OTP_ALPINE }}-arm64
       -
-        name: Install Packages
-        run: |
-          sudo apt update
-          sudo apt full-upgrade -y
-          sudo apt install buildah podman
-      -
         name: Build Image
         env: ${{ fromJson(steps.load-env.outputs.env) }}
         id: build-image
@@ -228,11 +216,6 @@ jobs:
         uses: ./.github/actions/load-otp-env
         with:
           otp-version: ${{ matrix.otp }}
-      -
-        name: Install Packages
-        run: |
-          sudo apt update
-          sudo apt install podman
       -
         name: Login to Registry
         run: |

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -247,6 +247,9 @@ jobs:
             
             echo "Creating manifest: $MANIFEST_NAME"
             
+            # Remove any existing local manifest to avoid conflicts
+            podman manifest rm "$MANIFEST_NAME" 2>/dev/null || true
+            
             # Create manifest
             podman manifest create "$MANIFEST_NAME"
             

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -49,18 +49,9 @@ jobs:
       -
         name: Load Env
         id: load-env
-        run: |
-          load=$(jq -cr '{"OTP_MAJOR": "${{ matrix.otp }}"} * (.otp."${{ matrix.otp }}" | with_entries(.key |= "OTP_" + ascii_upcase)) * (.rebar3."\(.otp."${{ matrix.otp }}".rebar3)" | with_entries(.key |= "REBAR3_" + ascii_upcase))' versions.json)
-          tag=$(echo $load | jq -cr ".OTP_VERSION + \":\" + .REBAR3_VERSION + \":$GITHUB_RUN_ID\"" | sha256sum | cut -b -7)
-          alpine_major_minor=$(echo "$load" | jq -cr '.OTP_ALPINE | split(".") | .[0:2] | join(".")')
-          load=$(echo "$load" | jq -cr ". + {\"TAG\":\"$tag\", \"ALPINE_MAJOR_MINOR\":\"$alpine_major_minor\"}")
-          echo "env=$load" >> $GITHUB_OUTPUT
-          # Export tags for manifest job
-          echo "otp_major=${{ matrix.otp }}" >> $GITHUB_OUTPUT
-          echo "otp_version=$(echo "$load" | jq -r '.OTP_VERSION')" >> $GITHUB_OUTPUT
-          echo "otp_alpine=$(echo "$load" | jq -r '.OTP_ALPINE')" >> $GITHUB_OUTPUT
-          echo "alpine_major_minor=$(echo "$load" | jq -r '.ALPINE_MAJOR_MINOR')" >> $GITHUB_OUTPUT
-          echo "build_tag=$(echo "$load" | jq -r '.TAG')" >> $GITHUB_OUTPUT
+        uses: ./.github/actions/load-otp-env
+        with:
+          otp-version: ${{ matrix.otp }}
       -
         name: Docker Metadata
         env: ${{ fromJson(steps.load-env.outputs.env) }}
@@ -146,12 +137,9 @@ jobs:
       -
         name: Load Env
         id: load-env
-        run: |
-          load=$(jq -cr '{"OTP_MAJOR": "${{ matrix.otp }}"} * (.otp."${{ matrix.otp }}" | with_entries(.key |= "OTP_" + ascii_upcase)) * (.rebar3."\(.otp."${{ matrix.otp }}".rebar3)" | with_entries(.key |= "REBAR3_" + ascii_upcase))' versions.json)
-          tag=$(echo $load | jq -cr ".OTP_VERSION + \":\" + .REBAR3_VERSION + \":$GITHUB_RUN_ID\"" | sha256sum | cut -b -7)
-          alpine_major_minor=$(echo "$load" | jq -cr '.OTP_ALPINE | split(".") | .[0:2] | join(".")')
-          load=$(echo "$load" | jq -cr ". + {\"TAG\":\"$tag\", \"ALPINE_MAJOR_MINOR\":\"$alpine_major_minor\"}")
-          echo "env=$load" >> $GITHUB_OUTPUT
+        uses: ./.github/actions/load-otp-env
+        with:
+          otp-version: ${{ matrix.otp }}
       -
         name: Docker Metadata
         env: ${{ fromJson(steps.load-env.outputs.env) }}
@@ -237,12 +225,9 @@ jobs:
       -
         name: Load Env
         id: load-env
-        run: |
-          load=$(jq -cr '{"OTP_MAJOR": "${{ matrix.otp }}"} * (.otp."${{ matrix.otp }}" | with_entries(.key |= "OTP_" + ascii_upcase)) * (.rebar3."\(.otp."${{ matrix.otp }}".rebar3)" | with_entries(.key |= "REBAR3_" + ascii_upcase))' versions.json)
-          tag=$(echo $load | jq -cr ".OTP_VERSION + \":\" + .REBAR3_VERSION + \":$GITHUB_RUN_ID\"" | sha256sum | cut -b -7)
-          alpine_major_minor=$(echo "$load" | jq -cr '.OTP_ALPINE | split(".") | .[0:2] | join(".")')
-          load=$(echo "$load" | jq -cr ". + {\"TAG\":\"$tag\", \"ALPINE_MAJOR_MINOR\":\"$alpine_major_minor\"}")
-          echo "env=$load" >> $GITHUB_OUTPUT
+        uses: ./.github/actions/load-otp-env
+        with:
+          otp-version: ${{ matrix.otp }}
       -
         name: Install Packages
         run: |


### PR DESCRIPTION
## Summary

This PR implements multi-architecture image builds using GitHub's native ARM64 runners and podman, eliminating the need for QEMU emulation which was causing build failures for Erlang/OTP on ARM64.

## Changes

### Architecture
- Split build process into separate jobs for AMD64 and ARM64
- Use `ubuntu-24.04` for AMD64 builds
- Use `ubuntu-24.04-arm64` for native ARM64 builds (no QEMU!)
- Add manifest job to create multi-arch image manifests using `podman manifest`

### Implementation Details

**Build Jobs:**
- `build-amd64`: Builds and pushes AMD64 images with `-amd64` suffix
- `build-arm64`: Builds and pushes ARM64 images with `-arm64` suffix
- Both jobs run in parallel for faster execution

**Manifest Job:**
- Creates multi-arch manifest lists for all tag variants
- Combines AMD64 and ARM64 images into unified manifests
- Pushes manifests with original tag names (without architecture suffix)

**Code Quality:**
- Created reusable composite action at `.github/actions/load-otp-env` to eliminate duplication
- Removed unnecessary package installation steps (tools are pre-installed on runners)

### Tag Structure

For each OTP version, the following images are created:

**Architecture-specific (intermediate):**
- `quay.io/travelping/alpine-erlang:27.3-amd64`
- `quay.io/travelping/alpine-erlang:27.3-arm64`

**Multi-arch (final):**
- `quay.io/travelping/alpine-erlang:27.3`
- `quay.io/travelping/alpine-erlang:27.3.4.8`
- `quay.io/travelping/alpine-erlang:27.3-alpine-3.21`
- (all tag variants as before)

## Benefits

✅ **Native compilation** - No more QEMU issues with ARM64 builds  
✅ **Parallel execution** - AMD64 and ARM64 build simultaneously  
✅ **Multi-arch support** - Final images work on both architectures transparently  
✅ **Podman-only** - No Docker dependency  
✅ **Faster builds** - Native ARM64 compilation is significantly faster than emulation  
✅ **Cleaner code** - DRY principle applied with reusable composite action

## Testing

Pull the multi-arch images and the container runtime will automatically select the correct architecture:

```bash
podman pull quay.io/travelping/alpine-erlang:27.3
```