### PR TITLE
feat(elixir): build Elixir base images on top of the Erlang images

### DIFF
--- a/.github/actions/load-elixir-env/action.yml
+++ b/.github/actions/load-elixir-env/action.yml
@@ -1,0 +1,38 @@
+name: 'Load Elixir Environment'
+description: 'Resolve OTP + Elixir build variables for an (OTP, Elixir) pair from versions.json'
+inputs:
+  otp-version:
+    description: 'OTP major version key from versions.json (e.g. 27.3)'
+    required: true
+  elixir-version:
+    description: 'Full Elixir version key from versions.json (e.g. 1.19.5)'
+    required: true
+outputs:
+  env:
+    description: 'JSON object with all environment variables'
+    value: ${{ steps.load-env.outputs.env }}
+
+runs:
+  using: 'composite'
+  steps:
+    - id: load-env
+      shell: bash
+      env:
+        OTP: ${{ inputs.otp-version }}
+        ELIXIR: ${{ inputs.elixir-version }}
+      run: |
+        set -euo pipefail
+        load=$(jq -cr --arg otp "$OTP" --arg elixir "$ELIXIR" '
+          .otp[$otp] as $o
+          | {
+              OTP_MAJOR: $otp,
+              OTP_VERSION: $o.version,
+              OTP_ALPINE: $o.alpine,
+              ALPINE_MAJOR_MINOR: ($o.alpine | split(".") | .[0:2] | join(".")),
+              ELIXIR_VERSION: $elixir,
+              ELIXIR_MINOR: ($elixir | split(".") | .[0:2] | join(".")),
+              ELIXIR_DOWNLOAD_SHA256: .elixir[$elixir].download_sha256
+            }' versions.json)
+        tag=$(echo "$load" | jq -cr ".ELIXIR_VERSION + \":\" + .OTP_VERSION + \":$GITHUB_RUN_ID\"" | sha256sum | cut -b -7)
+        load=$(echo "$load" | jq -cr ". + {\"TAG\":\"$tag\"}")
+        echo "env=$load" >> "$GITHUB_OUTPUT"

--- a/.github/actions/load-otp-env/action.yml
+++ b/.github/actions/load-otp-env/action.yml
@@ -15,7 +15,7 @@ runs:
     - id: load-env
       shell: bash
       run: |
-        load=$(jq -cr '{"OTP_MAJOR": "${{ inputs.otp-version }}"} * (.otp."${{ inputs.otp-version }}" | with_entries(.key |= "OTP_" + ascii_upcase)) * (.rebar3."\(.otp."${{ inputs.otp-version }}".rebar3)" | with_entries(.key |= "REBAR3_" + ascii_upcase))' versions.json)
+        load=$(jq -cr '{"OTP_MAJOR": "${{ inputs.otp-version }}"} * (.otp."${{ inputs.otp-version }}" | del(.elixir) | with_entries(.key |= "OTP_" + ascii_upcase)) * (.rebar3."\(.otp."${{ inputs.otp-version }}".rebar3)" | with_entries(.key |= "REBAR3_" + ascii_upcase))' versions.json)
         tag=$(echo $load | jq -cr ".OTP_VERSION + \":\" + .REBAR3_VERSION + \":$GITHUB_RUN_ID\"" | sha256sum | cut -b -7)
         alpine_major_minor=$(echo "$load" | jq -cr '.OTP_ALPINE | split(".") | .[0:2] | join(".")')
         load=$(echo "$load" | jq -cr ". + {\"TAG\":\"$tag\", \"ALPINE_MAJOR_MINOR\":\"$alpine_major_minor\"}")

--- a/.github/workflows/build-elixir.yaml
+++ b/.github/workflows/build-elixir.yaml
@@ -54,6 +54,13 @@ jobs:
           otp-version: ${{ inputs.otp-version }}
           elixir-version: ${{ inputs.elixir-version }}
       -
+        name: Log in to quay (base image pull)
+        env:
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+        run: |
+          printf '%s' "$QUAY_TOKEN" | buildah login -u "$QUAY_USERNAME" --password-stdin quay.io
+      -
         name: Build Image
         env: ${{ fromJson(steps.load-env.outputs.env) }}
         id: build-image
@@ -76,13 +83,10 @@ jobs:
       -
         name: Push temp arch tag
         env:
-          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
-          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
           BUILD_TAG: ${{ fromJson(steps.load-env.outputs.env).TAG }}
         run: |
           set -euo pipefail
           IMAGE="quay.io/travelping/${{ steps.repo.outputs.project }}"
-          printf '%s' "$QUAY_TOKEN" | buildah login -u "$QUAY_USERNAME" --password-stdin quay.io
           buildah push "${{ steps.build-image.outputs.image }}:amd64" "docker://${IMAGE}:${BUILD_TAG}-amd64"
           echo "Pushed temp tag: ${IMAGE}:${BUILD_TAG}-amd64 (expires 1d)"
 
@@ -116,6 +120,13 @@ jobs:
           otp-version: ${{ inputs.otp-version }}
           elixir-version: ${{ inputs.elixir-version }}
       -
+        name: Log in to quay (base image pull)
+        env:
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+        run: |
+          printf '%s' "$QUAY_TOKEN" | buildah login -u "$QUAY_USERNAME" --password-stdin quay.io
+      -
         name: Build Image
         env: ${{ fromJson(steps.load-env.outputs.env) }}
         id: build-image
@@ -138,13 +149,10 @@ jobs:
       -
         name: Push temp arch tag
         env:
-          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
-          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
           BUILD_TAG: ${{ fromJson(steps.load-env.outputs.env).TAG }}
         run: |
           set -euo pipefail
           IMAGE="quay.io/travelping/${{ steps.repo.outputs.project }}"
-          printf '%s' "$QUAY_TOKEN" | buildah login -u "$QUAY_USERNAME" --password-stdin quay.io
           buildah push "${{ steps.build-image.outputs.image }}:arm64" "docker://${IMAGE}:${BUILD_TAG}-arm64"
           echo "Pushed temp tag: ${IMAGE}:${BUILD_TAG}-arm64 (expires 1d)"
 

--- a/.github/workflows/build-elixir.yaml
+++ b/.github/workflows/build-elixir.yaml
@@ -1,0 +1,244 @@
+name: Build Elixir Image
+
+# Reusable workflow: build and publish the multi-arch Elixir image for a single
+# (OTP, Elixir) pair, layered on the already-published Erlang image. Mirrors
+# build-image.yaml: native per-arch build -> short-lived temp tag (quay auto-
+# expires it) -> manifest list -> Harbor mirror.
+
+on:
+  workflow_call:
+    inputs:
+      otp-version:
+        description: 'OTP major version key from versions.json (e.g. 27.3)'
+        required: true
+        type: string
+      elixir-version:
+        description: 'Full Elixir version key from versions.json (e.g. 1.19.5)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY_AUTH_FILE: /tmp/registry-auth.json
+
+jobs:
+  build-amd64:
+    runs-on: ubuntu-26.04
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      -
+        name: Choose Repository
+        id: repo
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          case "$REF" in
+            refs/heads/master)
+                echo "erlang=alpine-erlang" >> $GITHUB_OUTPUT
+                echo "project=alpine-elixir" >> $GITHUB_OUTPUT
+                ;;
+            *)
+                echo "erlang=alpine-erlang-dev" >> $GITHUB_OUTPUT
+                echo "project=alpine-elixir-dev" >> $GITHUB_OUTPUT
+                ;;
+          esac
+      -
+        name: Load Env
+        id: load-env
+        uses: ./.github/actions/load-elixir-env
+        with:
+          otp-version: ${{ inputs.otp-version }}
+          elixir-version: ${{ inputs.elixir-version }}
+      -
+        name: Build Image
+        env: ${{ fromJson(steps.load-env.outputs.env) }}
+        id: build-image
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
+        with:
+          image: elixir-build
+          tags: amd64
+          labels: |
+            quay.expires-after=1d
+          build-args: |
+            ERLANG_IMAGE=quay.io/travelping/${{ steps.repo.outputs.erlang }}:${{ env.OTP_VERSION }}
+            ELIXIR_VERSION=${{ env.ELIXIR_VERSION }}
+            ELIXIR_DOWNLOAD_SHA256=${{ env.ELIXIR_DOWNLOAD_SHA256 }}
+          platforms: linux/amd64
+          extra-args: |
+            --security-opt seccomp=unconfined
+          oci: true
+          containerfiles: |
+            ./Containerfile.elixir
+      -
+        name: Push temp arch tag
+        env:
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+          BUILD_TAG: ${{ fromJson(steps.load-env.outputs.env).TAG }}
+        run: |
+          set -euo pipefail
+          IMAGE="quay.io/travelping/${{ steps.repo.outputs.project }}"
+          printf '%s' "$QUAY_TOKEN" | buildah login -u "$QUAY_USERNAME" --password-stdin quay.io
+          buildah push "${{ steps.build-image.outputs.image }}:amd64" "docker://${IMAGE}:${BUILD_TAG}-amd64"
+          echo "Pushed temp tag: ${IMAGE}:${BUILD_TAG}-amd64 (expires 1d)"
+
+  build-arm64:
+    runs-on: ubuntu-26.04-arm
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      -
+        name: Choose Repository
+        id: repo
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          case "$REF" in
+            refs/heads/master)
+                echo "erlang=alpine-erlang" >> $GITHUB_OUTPUT
+                echo "project=alpine-elixir" >> $GITHUB_OUTPUT
+                ;;
+            *)
+                echo "erlang=alpine-erlang-dev" >> $GITHUB_OUTPUT
+                echo "project=alpine-elixir-dev" >> $GITHUB_OUTPUT
+                ;;
+          esac
+      -
+        name: Load Env
+        id: load-env
+        uses: ./.github/actions/load-elixir-env
+        with:
+          otp-version: ${{ inputs.otp-version }}
+          elixir-version: ${{ inputs.elixir-version }}
+      -
+        name: Build Image
+        env: ${{ fromJson(steps.load-env.outputs.env) }}
+        id: build-image
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
+        with:
+          image: elixir-build
+          tags: arm64
+          labels: |
+            quay.expires-after=1d
+          build-args: |
+            ERLANG_IMAGE=quay.io/travelping/${{ steps.repo.outputs.erlang }}:${{ env.OTP_VERSION }}
+            ELIXIR_VERSION=${{ env.ELIXIR_VERSION }}
+            ELIXIR_DOWNLOAD_SHA256=${{ env.ELIXIR_DOWNLOAD_SHA256 }}
+          platforms: linux/arm64
+          extra-args: |
+            --security-opt seccomp=unconfined
+          oci: true
+          containerfiles: |
+            ./Containerfile.elixir
+      -
+        name: Push temp arch tag
+        env:
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+          BUILD_TAG: ${{ fromJson(steps.load-env.outputs.env).TAG }}
+        run: |
+          set -euo pipefail
+          IMAGE="quay.io/travelping/${{ steps.repo.outputs.project }}"
+          printf '%s' "$QUAY_TOKEN" | buildah login -u "$QUAY_USERNAME" --password-stdin quay.io
+          buildah push "${{ steps.build-image.outputs.image }}:arm64" "docker://${IMAGE}:${BUILD_TAG}-arm64"
+          echo "Pushed temp tag: ${IMAGE}:${BUILD_TAG}-arm64 (expires 1d)"
+
+  manifest:
+    needs: [build-amd64, build-arm64]
+    runs-on: ubuntu-26.04
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      -
+        name: Choose Repository
+        id: repo
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          case "$REF" in
+            refs/heads/master)
+                echo "project=alpine-elixir" >> $GITHUB_OUTPUT
+                echo "harbor_ns=cennso" >> $GITHUB_OUTPUT
+                ;;
+            *)
+                echo "project=alpine-elixir-dev" >> $GITHUB_OUTPUT
+                echo "harbor_ns=cennso-dev" >> $GITHUB_OUTPUT
+                ;;
+          esac
+      -
+        name: Load Env
+        id: load-env
+        uses: ./.github/actions/load-elixir-env
+        with:
+          otp-version: ${{ inputs.otp-version }}
+          elixir-version: ${{ inputs.elixir-version }}
+      -
+        name: Log in to registries
+        env:
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+          HARBOR_DOMAIN: ${{ secrets.CUR_REGISTRY_DOMAIN }}
+          HARBOR_USERNAME: ${{ secrets.CUR_REGISTRY_USERNAME }}
+          HARBOR_PASSWORD: ${{ secrets.CUR_REGISTRY_PASSWORD }}
+        run: |
+          set -eu
+          printf '%s' "$QUAY_TOKEN" | podman login -u "$QUAY_USERNAME" --password-stdin quay.io
+          printf '%s' "$HARBOR_PASSWORD" | podman login -u "$HARBOR_USERNAME" --password-stdin "$HARBOR_DOMAIN"
+          echo "HARBOR_BASE=${HARBOR_DOMAIN}/${{ steps.repo.outputs.harbor_ns }}/elixir/alpine" >> "$GITHUB_ENV"
+          command -v skopeo >/dev/null || { sudo apt-get update && sudo apt-get install -y --no-install-recommends skopeo; }
+      -
+        name: Create and Push Multi-arch Manifests
+        env: ${{ fromJson(steps.load-env.outputs.env) }}
+        run: |
+          set -xeuo pipefail
+
+          IMAGE_BASE="quay.io/travelping/${{ steps.repo.outputs.project }}"
+          BUILD_TAG="${{ env.TAG }}"
+          AMD64_REF="${IMAGE_BASE}:${BUILD_TAG}-amd64"
+          ARM64_REF="${IMAGE_BASE}:${BUILD_TAG}-arm64"
+
+          E="${{ env.ELIXIR_VERSION }}"
+          EM="${{ env.ELIXIR_MINOR }}"
+          OV="${{ env.OTP_VERSION }}"
+          OM="${{ env.OTP_MAJOR }}"
+          AF="${{ env.OTP_ALPINE }}"
+          AMM="${{ env.ALPINE_MAJOR_MINOR }}"
+
+          TAGS=(
+            "${E}-otp-${OV}-alpine-${AF}"
+            "${E}-otp-${OV}-alpine-${AMM}"
+            "${E}-otp-${OV}"
+            "${E}-otp-${OM}"
+            "${EM}-otp-${OM}"
+          )
+
+          for TAG in "${TAGS[@]}"; do
+            MANIFEST_NAME="${IMAGE_BASE}:${TAG}"
+
+            echo "Creating manifest: $MANIFEST_NAME"
+            podman manifest rm "$MANIFEST_NAME" 2>/dev/null || true
+            podman manifest create "$MANIFEST_NAME"
+            podman manifest add "$MANIFEST_NAME" "docker://${AMD64_REF}"
+            podman manifest add "$MANIFEST_NAME" "docker://${ARM64_REF}"
+            podman manifest inspect "$MANIFEST_NAME"
+            podman manifest push --all "$MANIFEST_NAME" "docker://${MANIFEST_NAME}"
+            echo "Pushed multi-arch manifest to quay.io: $MANIFEST_NAME"
+
+            skopeo copy --multi-arch=all "docker://${MANIFEST_NAME}" "docker://${HARBOR_BASE}:${TAG}"
+            echo "Mirrored to Harbor: ${HARBOR_BASE}:${TAG}"
+          done
+      -
+        name: Print Summary
+        env: ${{ fromJson(steps.load-env.outputs.env) }}
+        run: |
+          echo -e "## Elixir image pushed\n" | tee -a $GITHUB_STEP_SUMMARY
+          echo "quay base: quay.io/travelping/${{ steps.repo.outputs.project }}" | tee -a $GITHUB_STEP_SUMMARY
+          echo "Harbor base: ${HARBOR_BASE}" | tee -a $GITHUB_STEP_SUMMARY
+          echo "Elixir ${{ env.ELIXIR_VERSION }} on OTP ${{ env.OTP_VERSION }} (alpine ${{ env.OTP_ALPINE }})" | tee -a $GITHUB_STEP_SUMMARY
+          echo "Per-arch temp tags (${{ env.TAG }}-amd64 / -arm64) auto-expire in 1d." | tee -a $GITHUB_STEP_SUMMARY

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-26.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      pairs: ${{ steps.set-matrix.outputs.pairs }}
     steps:
       -
         name: Checkout
@@ -24,6 +25,9 @@ jobs:
           matrix=$(jq -c '{"otp" : .otp | keys}' versions.json)
           echo "Matrix: $matrix"
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
+          pairs=$(jq -c '{"include": [ .otp | to_entries[] | .key as $otp | (.value.elixir // [])[] | {otp: $otp, elixir: .} ]}' versions.json)
+          echo "Pairs: $pairs"
+          echo "pairs=$pairs" >> $GITHUB_OUTPUT
 
   build:
     needs: matrix
@@ -33,4 +37,15 @@ jobs:
     uses: ./.github/workflows/build-image.yaml
     with:
       otp-version: ${{ matrix.otp }}
+    secrets: inherit
+
+  build-elixir:
+    needs: [matrix, build]
+    strategy:
+      matrix: ${{ fromJson(needs.matrix.outputs.pairs) }}
+      fail-fast: false
+    uses: ./.github/workflows/build-elixir.yaml
+    with:
+      otp-version: ${{ matrix.otp }}
+      elixir-version: ${{ matrix.elixir }}
     secrets: inherit

--- a/Containerfile.elixir
+++ b/Containerfile.elixir
@@ -1,0 +1,30 @@
+ARG ERLANG_IMAGE
+FROM ${ERLANG_IMAGE}
+
+ARG ELIXIR_VERSION
+ARG ELIXIR_DOWNLOAD_SHA256
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION=$ELIXIR_VERSION \
+    LANG=C.UTF-8
+
+LABEL org.opencontainers.image.version=$ELIXIR_VERSION
+
+RUN set -xe \
+	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/v${ELIXIR_VERSION}.tar.gz" \
+	&& apk add --no-cache --virtual .elixir-build-deps \
+		ca-certificates \
+		curl \
+		make \
+	&& curl -fSL -o elixir-src.tar.gz "$ELIXIR_DOWNLOAD_URL" \
+	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
+	&& mkdir -p /usr/local/src/elixir \
+	&& tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
+	&& rm elixir-src.tar.gz \
+	&& cd /usr/local/src/elixir \
+	&& make install clean \
+	&& find /usr/local/src/elixir/ -type f -not -regex "/usr/local/src/elixir/lib/[^\/]*/lib.*" -exec rm -rf {} + \
+	&& find /usr/local/src/elixir/ -type d -depth -empty -delete \
+	&& apk del .elixir-build-deps
+
+CMD ["iex"]

--- a/versions.json
+++ b/versions.json
@@ -4,25 +4,29 @@
 	    "alpine": "3.19.9",
 	    "rebar3": "3.22.1",
 	    "version": "26.2.5.21",
-	    "download_sha256": "e1fde86f4e2874d4c136221a34753b5b785d762b910fb3fb35a23a6a7faf0a64"
+	    "download_sha256": "e1fde86f4e2874d4c136221a34753b5b785d762b910fb3fb35a23a6a7faf0a64",
+	    "elixir": ["1.18.4", "1.19.5"]
 	},
 	"27.3":	{
 	    "alpine": "3.21.7",
 	    "rebar3": "3.24.0",
 	    "version": "27.3.4.14",
-	    "download_sha256": "cda7508a1aef446824f5fff4d64f1b1ad6365e7ad9a5f9d7300f6b6b3aef7015"
+	    "download_sha256": "cda7508a1aef446824f5fff4d64f1b1ad6365e7ad9a5f9d7300f6b6b3aef7015",
+	    "elixir": ["1.19.5", "1.20.2"]
 	},
 	"28.5":	{
 	    "alpine": "3.24.1",
 	    "rebar3": "3.27.0",
 	    "version": "28.5.0.3",
-	    "download_sha256": "63c56a954fe6134f283a01312ebefad00fb0f3ac7d7d42062ca3aa8e92ccd21d"
+	    "download_sha256": "63c56a954fe6134f283a01312ebefad00fb0f3ac7d7d42062ca3aa8e92ccd21d",
+	    "elixir": ["1.19.5", "1.20.2"]
 	},
 	"29.0":	{
 	    "alpine": "3.24.1",
 	    "rebar3": "3.27.0",
 	    "version": "29.0.3",
-	    "download_sha256": "f920c660b16794bcb7270d1cbf680f7747c719650bcd6ac449508a32c2a8972a"
+	    "download_sha256": "f920c660b16794bcb7270d1cbf680f7747c719650bcd6ac449508a32c2a8972a",
+	    "elixir": ["1.20.2"]
 	}
    },
     "rebar3": {
@@ -49,6 +53,20 @@
 	"3.27.0": {
 	    "version": "3.27.0",
 	    "download_sha256": "985cae6e957334cfa549190b9f5efb9185c184a18fc181c87b8dde096ba79f38"
+	}
+    },
+    "elixir": {
+	"1.18.4": {
+	    "version": "1.18.4",
+	    "download_sha256": "8e136c0a92160cdad8daa74560e0e9c6810486bd232fbce1709d40fcc426b5e0"
+	},
+	"1.19.5": {
+	    "version": "1.19.5",
+	    "download_sha256": "10750b8bd74b10ac1e25afab6df03e3d86999890fa359b5f02aa81de18a78e36"
+	},
+	"1.20.2": {
+	    "version": "1.20.2",
+	    "download_sha256": "1a25bbf9a9016651fc332eecc02bb9681d0b8e722c2e256e73ddb88fbce6e6b0"
 	}
     }
 }


### PR DESCRIPTION
## Summary

Adds Elixir base images layered on the repo's Erlang images. Erlang images are unchanged; Elixir is published as new images. Each OTP major ships the latest two Elixir minors that support it, with full parity to the Erlang pipeline (native multi-arch amd64+arm64, temp-tag → manifest → Harbor mirror).

## Elixir ↔ OTP matrix (in `versions.json`)

| OTP | Elixir |
|---|---|
| 26.2 | 1.18.4, 1.19.5 |
| 27.3 | 1.19.5, 1.20.2 |
| 28.5 | 1.19.5, 1.20.2 |
| 29.0 | 1.20.2 |

Rule: the latest two Elixir minors that support each OTP (1.20 doesn't support OTP 26, so 26.2 keeps 1.18).

## What's here

- **`versions.json`**: each OTP entry gains an optional `elixir` list; new top-level `elixir` lookup section (mirrors the `rebar3` pattern; SHAs from the GitHub archive tarball).
- **`Containerfile.elixir`**: builds Elixir from source `FROM ${ERLANG_IMAGE}` (matches the official erlef/docker-elixir alpine approach — arch-neutral BEAM bytecode, no C toolchain).
- **`.github/actions/load-elixir-env`**: composite resolving the OTP+Elixir build vars for a pair.
- **`.github/workflows/build-elixir.yaml`**: reusable workflow — native per-arch build → short-lived `quay.expires-after` temp tag → manifest → `skopeo copy --multi-arch=all` to Harbor.
- **`.github/workflows/images.yaml`**: emits `(OTP, Elixir)` pairs and fans out a `build-elixir` job (`needs: build`) after the Erlang build.

## Registries

- quay: `travelping/alpine-elixir` (master) / `alpine-elixir-dev` (otherwise)
- Harbor: `cennso/elixir/alpine` (master) / `cennso-dev/elixir/alpine` (otherwise)

Tag aliases per pair (Elixir-led): `<elixir>-otp-<otp_version>-alpine-<alpine_full|mm>`, `<elixir>-otp-<otp_version>`, `<elixir>-otp-<otp_major>`, `<elixir_minor>-otp-<otp_major>`.

## Validation

Full CI green on the dev targets: `matrix` + 12 Erlang jobs + **21 Elixir jobs** (7 pairs × amd64/arm64/manifest), including the quay push and Harbor mirror for every pair.

## Notes for reviewers

- `load-otp-env` now does `del(.elixir)` so the new `elixir` list on OTP entries stays out of the Erlang build's env (it would otherwise become an array-valued `OTP_ELIXIR` that `env: fromJson(...)` rejects).
- The `build-elixir` build jobs log in to quay before the `FROM` pull (the Erlang base repo is private, unlike the public `docker.io/alpine` base the Erlang build uses).
- Provisioning done: quay `alpine-elixir[-dev]` created with CI-robot write; Harbor `cennso[-dev]/elixir/alpine` push confirmed.
- **Before this runs on master**, confirm the non-dev targets (quay `alpine-elixir`, Harbor `cennso/elixir/alpine`) grant the robot push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)